### PR TITLE
Implementation: New representation of enum-sets, misc. updates

### DIFF
--- a/implementation-README.md
+++ b/implementation-README.md
@@ -1,26 +1,7 @@
 # Enums
 
-This is an implementation of enumerated types for Scheme, based on a
-[pre-SRFI specification](https://bitbucket.org/cowan/r7rs-wg1-infra/src/default/EnumsCowan.md)
-by John Cowan.
-
-From the pre-SRFI's Rationale:
-
-> Many procedures in many libraries accept arguments from a finite set
-> (usually a fairly small one), or subsets of a finite set to describe
-> one or more modes of operation.  Offering a mechanism for dealing with
-> such values fosters portable and readable code, much as records do for
-> compound values, or multiple values for procedures computing several
-> results.
->
-> This SRFI ...  provides something related to the *enums* of Java
-> version 5 and later.  These are objects of a type disjoint from all
-> others that are grouped into *enumeration types* (called *enum
-> classes* in Java).  In Java, each enumeration type is allowed to
-> declare the number and types of values associated with each object,
-> but in this SRFI an enumeration object has exactly one value; this is
-> useful when translating from C to record the numeric value, but has
-> other uses as well.
+This is an implementation of [SRFI 209](https://srfi.schemers.org/srfi-209),
+which provides enumerated types for Scheme.
 
 # Requirements
 
@@ -31,14 +12,23 @@ with the following libraries from R7RS-large:
 * `(scheme comparator)` ([SRFI 128](https://srfi.schemers.org/srfi-128)
   with or without [SRFI 162](https://srfi.schemers.org/srfi-162))
 * `(scheme mapping)` ([SRFI 146](https://srfi.schemers.org/srfi-146))
-  and `(scheme mapping hash)`.
+* `(scheme bitwise)` ([SRFI 151](https://srfi.schemers.org/srfi-151))
 
 [SRFI 145](https://srfi.schemers.org/srfi-145) is an optional
 dependency.  [SRFI 78](https://srfi.schemers.org/srfi-78) is used for
-the test set, which can be run simply by loading `test.scm`.  A basic
-fallback framework is provided for Schemes without SRFI 78.
+the test set, which can be run simply by loading `test.scm`.  (A basic
+fallback framework is provided for Schemes without SRFI 78.)  A copy
+of the test suite for [chibi-scheme](http://synthcode.com/scheme/chibi/),
+using the `(chibi test)` module.
 
-# Author
+# Implementation notes
+
+Enum-sets are implemented as integer bitmaps.  Though this gives
+excellent performance in the case of small sets (e.g. those which
+can be represented by a single fixnum), large sets may perform
+less well.
+
+# Implementation author
 
 Wolfgang Corcoran-Mathe
 

--- a/srfi-209-chibi-test.scm
+++ b/srfi-209-chibi-test.scm
@@ -348,15 +348,15 @@
   (test (length color-names) (enum-set-size color-set))
   (test 0 (enum-set-size empty-colors))
 
-  (test-assert (equal? (enum-set->list color-set) (enum-type-enums color)))
-  (test-assert (null? (enum-set->list empty-colors)))
+  (test-assert (equal? (enum-set->enum-list color-set) (enum-type-enums color)))
+  (test-assert (null? (enum-set->enum-list empty-colors)))
   (test-assert (= (enum-set-size color-set)
-                  (length (enum-set->list color-set))))
+                  (length (enum-set->enum-list color-set))))
 
   (test color-names (enum-set-map->list enum-name color-set))
   (test-assert (null? (enum-set-map->list enum-name empty-colors)))
   (test-assert (equal? (enum-set-map->list enum-name color-set)
-                       (map enum-name (enum-set->list color-set))))
+                       (map enum-name (enum-set->enum-list color-set))))
 
   (test 1 (enum-set-count (lambda (e) (enum=? e color-blue)) color-set))
   (test 0 (enum-set-count (lambda (e) (enum=? e color-blue)) reddish))
@@ -407,7 +407,7 @@
                         (map (lambda (sym) (enum-name->enum light-type sym))
                              ds)))
     (test-assert (every (lambda (e) (eqv? (enum-name e) (enum-value e)))
-                        (enum-set->list us-traffic-light))))
+                        (enum-set->enum-list us-traffic-light))))
 
   (let ((color-con (enum-set-constructor reddish)))
     (test-assert (eqv? (enum-set-type (color-con '(green))) color))

--- a/srfi-209-chibi-test.scm
+++ b/srfi-209-chibi-test.scm
@@ -392,12 +392,14 @@
 
   (test-assert (enum-set=? color-set (enum-set-universe reddish)))
 
-  (let* ((ds '((red "stop") (yellow "floor it!") (green "go")))
+  (let* ((ds '(red yellow green))
          (us-traffic-light (make-enumeration ds))
          (light-type (enum-set-type us-traffic-light)))
     (test-assert (every (lambda (e) (enum-set-contains? us-traffic-light e))
-                        (map (lambda (p) (enum-name->enum light-type (car p)))
-                             ds))))
+                        (map (lambda (sym) (enum-name->enum light-type sym))
+                             ds)))
+    (test-assert (every (lambda (e) (eqv? (enum-name e) (enum-value e)))
+                        (enum-set->list us-traffic-light))))
 
   (let ((color-con (enum-set-constructor reddish)))
     (test-assert (eqv? (enum-set-type (color-con '(green))) color))

--- a/srfi-209-chibi-test.scm
+++ b/srfi-209-chibi-test.scm
@@ -287,6 +287,14 @@
   (test-assert (enum-set>=? color-set reddish))
   (test-assert (enum-set>=? color-set color-set))
 
+  ;;; enum-set-subset?
+  (test-assert (enum-set-subset? reddish color-set))
+  (test-not    (enum-set-subset? color-set reddish))
+  (test-assert (enum-set-subset? reddish reddish))
+  (let ((color-set* (make-enumeration '(red green blue))))
+    (test-assert (enum-set-subset? color-set* color-set))
+    (test-not    (enum-set-subset? color-set color-set*)))
+
   ;;; any & every
 
   (test-assert (enum-set-any? (lambda (e) (eq? 'green (enum-name e)))

--- a/srfi-209-chibi-test.scm
+++ b/srfi-209-chibi-test.scm
@@ -336,7 +336,8 @@
     (test-not    (enum-set-contains? reddish** color-tangerine)))
 
   (test-assert (enum-set-empty?
-                (enum-set-delete-all! color-set (enum-type-enums color))))
+                (enum-set-delete-all! (enum-set-copy color-set)
+                                      (enum-type-enums color))))
 )
 
 (test-group "Derived enum set operations"

--- a/srfi-209-chibi-test.scm
+++ b/srfi-209-chibi-test.scm
@@ -353,10 +353,15 @@
   (test-assert (= (enum-set-size color-set)
                   (length (enum-set->enum-list color-set))))
 
+  (test color-names (enum-set->list color-set))
+  (test (map car pizza-descriptions)
+        (enum-set->list (enum-type->enum-set pizza)))
+  (test (enum-set-size color-set) (length (enum-set->enum-list color-set)))
+
   (test color-names (enum-set-map->list enum-name color-set))
   (test-assert (null? (enum-set-map->list enum-name empty-colors)))
   (test-assert (equal? (enum-set-map->list enum-name color-set)
-                       (map enum-name (enum-set->enum-list color-set))))
+                       (enum-set->list color-set)))
 
   (test 1 (enum-set-count (lambda (e) (enum=? e color-blue)) color-set))
   (test 0 (enum-set-count (lambda (e) (enum=? e color-blue)) reddish))

--- a/srfi-209-chibi-test.scm
+++ b/srfi-209-chibi-test.scm
@@ -69,9 +69,7 @@
                          (enum-name->enum color ord))
                        (drop color-names 3))))
 
-(define empty-colors
-  (enum-set-delete-all! (enum-set-copy color-set)
-                        (enum-type-enums color)))
+(define empty-colors (enum-empty-set color))
 
 (define pizza-descriptions
   '((margherita "tomato and mozzarella")
@@ -253,9 +251,7 @@
   (test-assert (enum-set-empty? empty-colors))
   (test-not (enum-set-empty? color-set))
 
-  (test-assert
-   (enum-set=? (enum-set-projection (enum-type->enum-set color) reddish)
-               reddish))
+  (test-assert (enum-set=? (enum-set-projection color reddish) reddish))
   (let* ((color* (make-enum-type color-names))
          (reddish* (list->enum-set color*
                                    (map (lambda (name)
@@ -388,7 +384,7 @@
                              color-set)
           n))
 
-  (test (reverse color-names)
+  (test color-names
         (enum-set-fold (lambda (enum lis)
                          (cons (enum-name enum) lis))
                        '()

--- a/srfi-209-test.scm
+++ b/srfi-209-test.scm
@@ -107,9 +107,7 @@
                          (enum-name->enum color ord))
                        (drop color-names 3))))
 
-(define empty-colors
-  (enum-set-delete-all! (enum-set-copy color-set)
-                        (enum-type-enums color)))
+(define empty-colors (enum-empty-set color))
 
 (define pizza-descriptions
   '((margherita "tomato and mozzarella")
@@ -472,7 +470,7 @@
                           (cons (enum-name enum) lis))
                         '()
                         color-set)
-   => (reverse color-names))
+   => color-names)
 
   (check (enum-set=? color-set (enum-set-universe reddish)) => #t)
 

--- a/srfi-209-test.scm
+++ b/srfi-209-test.scm
@@ -351,6 +351,14 @@
   (check (enum-set>=? color-set reddish)     => #t)
   (check (enum-set>=? color-set color-set)   => #t)
 
+  ;;; enum-set-subset?
+  (check (enum-set-subset? reddish color-set) => #t)
+  (check (enum-set-subset? color-set reddish) => #f)
+  (check (enum-set-subset? reddish reddish)   => #t)
+  (let ((color-set* (make-enumeration '(red green blue))))
+    (check (enum-set-subset? color-set* color-set) => #t)
+    (check (enum-set-subset? color-set color-set*) => #f))
+
   ;;; any & every
 
   (check (enum-set-any? (lambda (e) (eq? 'green (enum-name e)))

--- a/srfi-209-test.scm
+++ b/srfi-209-test.scm
@@ -474,12 +474,15 @@
 
   (check (enum-set=? color-set (enum-set-universe reddish)) => #t)
 
-  (let* ((ds '((red "stop") (yellow "floor it!") (green "go")))
+  (let* ((ds '(red yellow green))
          (us-traffic-light (make-enumeration ds))
          (light-type (enum-set-type us-traffic-light)))
     (check (every (lambda (e) (enum-set-contains? us-traffic-light e))
-                  (map (lambda (p) (enum-name->enum light-type (car p)))
+                  (map (lambda (sym) (enum-name->enum light-type sym))
                        ds))
+     => #t)
+    (check (every (lambda (e) (eqv? (enum-name e) (enum-value e)))
+                  (enum-set->list us-traffic-light))
      => #t))
 
   (let ((color-con (enum-set-constructor reddish)))

--- a/srfi-209-test.scm
+++ b/srfi-209-test.scm
@@ -405,7 +405,8 @@
     (check (enum-set-contains? reddish** color-tangerine) => #f))
 
   (check (enum-set-empty?
-          (enum-set-delete-all! color-set (enum-type-enums color)))
+          (enum-set-delete-all! (enum-set-copy color-set)
+                                (enum-type-enums color)))
    => #t)
 )
 

--- a/srfi-209-test.scm
+++ b/srfi-209-test.scm
@@ -428,10 +428,16 @@
             (length (enum-set->enum-list color-set)))
    => #t)
 
+  (check (enum-set->list color-set) => color-names)
+  (check (enum-set->list (enum-type->enum-set pizza))
+   => (map car pizza-descriptions))
+  (check (length (enum-set->enum-list color-set))
+   => (enum-set-size color-set))
+
   (check (enum-set-map->list enum-name color-set)    => color-names)
   (check (enum-set-map->list enum-name empty-colors) => '())
   (check (equal? (enum-set-map->list enum-name color-set)
-                 (map enum-name (enum-set->enum-list color-set)))
+                 (enum-set->list color-set))
    => #t)
 
   (check (enum-set-count (lambda (e) (enum=? e color-blue)) color-set)

--- a/srfi-209-test.scm
+++ b/srfi-209-test.scm
@@ -422,16 +422,16 @@
   (check (enum-set-size color-set) => (length color-names))
   (check (enum-set-size empty-colors) => 0)
 
-  (check (equal? (enum-set->list color-set) (enum-type-enums color)) => #t)
-  (check (null? (enum-set->list empty-colors)) => #t)
+  (check (equal? (enum-set->enum-list color-set) (enum-type-enums color)) => #t)
+  (check (null? (enum-set->enum-list empty-colors)) => #t)
   (check (= (enum-set-size color-set)
-            (length (enum-set->list color-set)))
+            (length (enum-set->enum-list color-set)))
    => #t)
 
   (check (enum-set-map->list enum-name color-set)    => color-names)
   (check (enum-set-map->list enum-name empty-colors) => '())
   (check (equal? (enum-set-map->list enum-name color-set)
-                 (map enum-name (enum-set->list color-set)))
+                 (map enum-name (enum-set->enum-list color-set)))
    => #t)
 
   (check (enum-set-count (lambda (e) (enum=? e color-blue)) color-set)
@@ -490,7 +490,7 @@
                        ds))
      => #t)
     (check (every (lambda (e) (eqv? (enum-name e) (enum-value e)))
-                  (enum-set->list us-traffic-light))
+                  (enum-set->enum-list us-traffic-light))
      => #t))
 
   (let ((color-con (enum-set-constructor reddish)))

--- a/srfi/209.scm
+++ b/srfi/209.scm
@@ -247,6 +247,7 @@
   (assume (enum-set? eset))
   (let ((type (if (enum-type? src) src (enum-set-type src))))
     (list->enum-set
+     type
      (enum-set-map->list (lambda (enum)
                            (enum-name->enum type (enum-name enum)))
                          eset))))

--- a/srfi/209.scm
+++ b/srfi/209.scm
@@ -475,9 +475,12 @@
   (assume (enum-set? eset))
   (bit-count (enum-set-bitmap eset)))
 
-(define (enum-set->list eset)
+(define (enum-set->enum-list eset)
   (assume (enum-set? eset))
   (enum-set-fold cons '() eset))
+
+(define (enum-set->list eset)
+  (enum-set-map->list enum-name eset))
 
 (define (enum-set-map->list proc eset)
   (assume (procedure? proc))

--- a/srfi/209.scm
+++ b/srfi/209.scm
@@ -345,8 +345,19 @@
   (zero? (bitwise-andc1 (enum-set-bitmap eset1)
                         (enum-set-bitmap eset2))))
 
+(define (%enum-set->name-mapping eset)
+  (mapping-unfold null?
+                  (lambda (syms) (values (car syms) #t))
+                  cdr
+                  (enum-set-map->list enum-name eset)
+                  symbol-comparator))
+
 (define (enum-set-subset? eset1 eset2)
-  (enum-set<=? eset1 eset2))
+  (assume (enum-set? eset1))
+  (assume (enum-set? eset2))
+  (mapping<=? symbol-comparator
+              (%enum-set->name-mapping eset1)
+              (%enum-set->name-mapping eset2)))
 
 (define (enum-set-any? pred eset)
   (assume (procedure? pred))

--- a/srfi/209.scm
+++ b/srfi/209.scm
@@ -257,7 +257,7 @@
 
 ;; [Deprecated]
 (define (make-enumeration names)
-  (enum-type->enum-set (make-enum-type names)))
+  (enum-type->enum-set (make-enum-type (zip names names))))
 
 ;; [Deprecated]
 (define (enum-set-universe eset)

--- a/srfi/209.scm
+++ b/srfi/209.scm
@@ -240,19 +240,16 @@
          0
          enums)))
 
-;; Returns a set of enums drawn from the enum-type src with the same
-;; names as the enums of eset.
+;; Returns a set of enums drawn from the enum-type/-set src with
+;; the same names as the enums of eset.
 (define (enum-set-projection src eset)
   (assume (or (enum-type? src) (enum-set? src)))
   (assume (enum-set? eset))
   (let ((type (if (enum-type? src) src (enum-set-type src))))
-    (make-enum-set
-     type
-     (mapping-map (lambda (_ enum)
-                    (let ((enum* (enum-name->enum type (enum-name enum))))
-                      (values (enum-ordinal enum*) enum*)))
-                  real-comparator
-                  (enum-set-mapping eset)))))
+    (list->enum-set
+     (enum-set-map->list (lambda (enum)
+                           (enum-name->enum type (enum-name enum)))
+                         eset))))
 
 (define (enum-set-copy eset)
   (make-enum-set (enum-set-type eset) (enum-set-bitmap eset)))

--- a/srfi/209.scm
+++ b/srfi/209.scm
@@ -433,7 +433,8 @@
        (set-enum-set-bitmap!
         eset
         (bitwise-andc2 (enum-set-bitmap eset)
-                       (expt 2 (enum-ordinal enum))))))
+                       (expt 2 (enum-ordinal enum))))
+       eset))
     ((eset . enums)             ; variadic path
      (enum-set-delete-all! eset enums))))
 
@@ -450,10 +451,12 @@
   (assume (or (pair? enums) (null? enums)))
   (if (null? enums)
       eset
-      (set-enum-set-bitmap!
-       eset
-       (bitwise-andc2 (enum-set-bitmap eset)
-                      (%enum-list->bitmap (enum-set-type eset) enums)))))
+      (begin
+       (set-enum-set-bitmap!
+        eset
+        (bitwise-andc2 (enum-set-bitmap eset)
+                       (%enum-list->bitmap (enum-set-type eset) enums)))
+       eset)))
 
 ;;;; Enum set operations
 

--- a/srfi/209.scm
+++ b/srfi/209.scm
@@ -368,10 +368,9 @@
 ;; Fold a list of enums into a bitmap of their ordinals.
 (define (%enum-list->bitmap type enums)
   (fold (lambda (enum b)
-          (assume (%well-typed-enum? type enum)
-                  "enum-set-adjoin: invalid argument")
+          (assume (%well-typed-enum? type enum))
           (bitwise-ior b (expt 2 (enum-ordinal enum))))
-        (enum-set-bitmap eset)
+        0
         enums))
 
 (define enum-set-adjoin

--- a/srfi/209.scm
+++ b/srfi/209.scm
@@ -402,13 +402,15 @@
      (set-enum-set-bitmap!
       eset
       (bitwise-ior (enum-set-bitmap eset)
-                   (expt 2 (enum-ordinal enum)))))
+                   (expt 2 (enum-ordinal enum))))
+     eset)
     ((eset . enums)              ; variadic path
      (assume (enum-set? eset))
      (set-enum-set-bitmap!
       eset
       (bitwise-ior (enum-set-bitmap eset)
-                   (%enum-list->bitmap (enum-set-type eset) enums))))))
+                   (%enum-list->bitmap (enum-set-type eset) enums)))
+     eset)))
 
 (define enum-set-delete
   (case-lambda

--- a/srfi/209.scm
+++ b/srfi/209.scm
@@ -215,7 +215,7 @@
 ;;;; Enum set constructors
 
 (define-record-type <enum-set>
-  (make-enum-set type mapping)
+  (make-enum-set type bitmap)
   enum-set?
   (type enum-set-type)
   (bitmap enum-set-bitmap set-enum-set-bitmap!))

--- a/srfi/209.sld
+++ b/srfi/209.sld
@@ -1,5 +1,6 @@
 (define-library (srfi 209)
   (import (scheme base)
+          (scheme case-lambda)
           (srfi 1)
           (srfi 128)
           (srfi 151)

--- a/srfi/209.sld
+++ b/srfi/209.sld
@@ -2,6 +2,7 @@
   (import (scheme base)
           (srfi 1)
           (srfi 128)
+          (srfi 151)
           (srfi 146))
 
   (cond-expand

--- a/srfi/209.sld
+++ b/srfi/209.sld
@@ -50,6 +50,7 @@
 
           enum-set-size enum-set->list enum-set-map->list enum-set-for-each
           enum-set-filter enum-set-remove enum-set-count enum-set-fold
+          enum-set->enum-list
 
           enum-set-union enum-set-intersection enum-set-difference
           enum-set-xor enum-set-complement enum-set-union!


### PR DESCRIPTION
These commits change the implementation of enum-sets and implement John's latest clarifications and edits. Still TODO is the fast syntax-case version of define-enum requested by Marc Nieper-Wißkirchen. Otherwise, everything is in last-call shape. Thanks.