### PR TITLE
Tests: Move definitions to top of procedure body.

### DIFF
--- a/srfi-209-test.scm
+++ b/srfi-209-test.scm
@@ -546,10 +546,10 @@
 )
 
 (define (check-syntax)
-  (print-header "Running syntax tests...")
-
   (define-enum hobbit (frodo sam merry pippin) hobbit-set)
   (define-enumeration wizard (gandalf saruman radagast) wizard-set)
+
+  (print-header "Running syntax tests...")
 
   (check (enum-name (hobbit merry)) => 'merry)
   (check (enum-set? (hobbit-set)) => #t)


### PR DESCRIPTION
This fixes the error described in #8.  Thanks.