### PR TITLE
Corrections in procedure entries

### DIFF
--- a/srfi-209.html
+++ b/srfi-209.html
@@ -207,27 +207,27 @@ exact-integer</em><code>)</code></p>
 unique.</p>
 <p>The following convenience procedures provide enum-finding followed by access
 to a property.</p>
-<p><code>(enum-name-&gt;ordinal</code>&nbsp;<em>enum-set
+<p><code>(enum-name-&gt;ordinal</code>&nbsp;<em>enum-type
 symbol</em><code>)</code></p>
 <p>Returns the ordinal of the enum belonging to <em>enum-type</em> whose name is
 <em>symbol</em>. It is an error if there is no such enum.</p>
 <pre class="example"><code>(enum-name-&gt;ordinal color 'blue) &rArr; 5
 </code></pre>
-<p><code>(enum-name-&gt;value</code>&nbsp;<em>enum-set
+<p><code>(enum-name-&gt;value</code>&nbsp;<em>enum-type
 symbol</em><code>)</code></p>
 <p>Returns the value of the enum belonging to <em>enum-type</em> whose name is
 <em>symbol</em>. It is an error if there is no such enum.</p>
 <pre class="example"><code>(enum-name-&gt;value pizza 'funghi) &rArr; "mushrooms"
 (enum-name-&gt;value color 'blue) &rArr; 5
 </code></pre>
-<p><code>(enum-ordinal-&gt;name</code>&nbsp;<em>enum-set
+<p><code>(enum-ordinal-&gt;name</code>&nbsp;<em>enum-type
 exact-integer</em><code>)</code></p>
 <p>Returns the name of the enum belonging to <em>enum-type</em> whose ordinal is
 <em>exact-integer</em>. It is an error if there is no such enum.</p>
 <pre class="example"><code>(enum-ordinal-&gt;name color 0) &rArr; red
 (enum-ordinal-&gt;name pizza 3) &rArr; hawaiian
 </code></pre>
-<p><code>(enum-ordinal-&gt;value</code>&nbsp;<em>enum-set
+<p><code>(enum-ordinal-&gt;value</code>&nbsp;<em>enum-type
 exact-integer</em><code>)</code></p>
 <p>Returns the value of the enum belonging to <em>enum-type</em> whose ordinal
 is <em>exact-integer</em>. It is an error if there is no such enum.</p>
@@ -596,8 +596,10 @@ of the result do not belong to the same enum type.</p>
 
 (enum-set=? color-set (enum-set-union! reddish ~reddish)) &rArr; #t
 </code></pre>
-<code>(enum-set-intersection!</code>&nbsp;<em>enum-set-1
+<p><code>(enum-set-intersection</code>&nbsp;<em>enum-set-1
 enum-set-2</em><code>)</code><br/>
+<code>(enum-set-intersection!</code>&nbsp;<em>enum-set-1
+enum-set-2</em><code>)</code></p>
 <p>Returns an enum set containing all the elements that appear in both
 <em>enum-set-1</em> and <em>enum-set-2</em>. It is an error if all the elements
 of the result do not belong to the same enum type.</p>


### PR DESCRIPTION
- The first argument of `enum-name->ordinal`, `enum-name->value`,
  `enum-ordinal->name` and `enum-ordinal->value` must be enum-type,
  not enum-set.
- Entry of `enum-set-intersection` (functional API) is missing.