### PR TITLE
contrib: Efficient version of defin-enum

### DIFF
--- a/contrib/define-enum-sc.scm
+++ b/contrib/define-enum-sc.scm
@@ -27,7 +27,7 @@
                      ((idx ...) (iota (length #'(name-val ...)))))
          (unless (unique-ids? #'(name ...))
            (syntax-violation 'define-enum
-             "duplicated enum names" stx #'(name ...)))
+             "duplicated enum names" stx #'(quote (name ...))))
          (syntax
           (begin
            (define new-type (make-enum-type '(name-val ...)))
@@ -37,12 +37,12 @@
              (syntax-rules (name ...)
                ((_ loc name) idx) ...
                ((_ loc x)
-                (syntax-violation 'loc "invalid enum name" x))))
+                (syntax-violation 'loc "invalid enum name" 'x))))
 
            (define-syntax type-name
              (syntax-rules ()
                ((_ (x . _))
-                (syntax-violation 'type-name "invalid syntax" (x . _)))
+                (syntax-violation 'type-name "invalid syntax" 'x))
                ((_ id)
                 (%enum-ordinal->enum-no-assert
                  new-type

--- a/contrib/define-enum-sc.scm
+++ b/contrib/define-enum-sc.scm
@@ -1,0 +1,43 @@
+(import (rnrs)
+        (rnrs syntax-case (6))
+        (only (srfi :1) find iota))
+
+(define-syntax define-enum
+  (lambda (stx)
+    (define (parse-name-val nv-syn)
+      (syntax-case nv-syn ()
+        (id (identifier? #'id) #'id)
+        ((id _) (identifier? #'id) #'id)
+        (_ (syntax-violation 'define-enum
+            "invalid enum syntax" stx nv-syn))))
+
+    (define (unique-ids? ids)
+      (let unique ((ids ids))
+        (or (null? ids)
+            (let ((id (car ids)) (rest (cdr ids)))
+              (and (not (find (lambda (x) (free-identifier=? x id))
+                              rest))
+                   (unique rest))))))
+
+    (syntax-case stx ()
+      ((_ type-name (name-val ...) constructor)
+       (and (identifier? #'type-name)
+            (identifier? #'constructor))
+       (with-syntax (((name ...) (map parse-name-val #'(name-val ...)))
+                     ((i ...) (iota (length #'(name-val ...)))))
+         (unless (unique-ids? #'(name ...))
+           (syntax-violation 'define-enum
+             "duplicated enum names" stx #'(name ...)))
+         (syntax
+          (begin
+           (define new-type (make-enum-type '(name-val ...)))
+
+           (define-syntax type-name
+             (syntax-rules (name ...)
+               ((_ name)
+                (%enum-ordinal->enum-no-assert new-type i)) ...
+               ((_ (x . _))
+                (syntax-violation 'type-name "invalid syntax" x))
+               ((_ id)
+                (syntax-violation 'type-name "invalid enum name" id))))
+          )))))))

--- a/contrib/define-enum-sc.scm
+++ b/contrib/define-enum-sc.scm
@@ -42,7 +42,7 @@
                 (syntax-violation 'type-name "invalid enum name" id))))
 
            (...  ; escape ellipsis for the following
-           (define-syntax constructor
-             (syntax-rules ()
-               ((_ arg ...)
-                (enum-set new-type (type-name arg) ...))))))))))))
+            (define-syntax constructor
+              (syntax-rules ()
+                ((_ arg ...)
+                 (enum-set new-type (type-name arg) ...))))))))))))

--- a/contrib/define-enum-sc.scm
+++ b/contrib/define-enum-sc.scm
@@ -41,7 +41,8 @@
                ((_ id)
                 (syntax-violation 'type-name "invalid enum name" id))))
 
+           (...  ; escape ellipsis for the following
            (define-syntax constructor
              (syntax-rules ()
                ((_ arg ...)
-                (enum-set new-type (type-name arg) ...)))))))))))
+                (enum-set new-type (type-name arg) ...))))))))))))

--- a/contrib/define-enum-sc.scm
+++ b/contrib/define-enum-sc.scm
@@ -24,7 +24,7 @@
        (and (identifier? #'type-name)
             (identifier? #'constructor))
        (with-syntax (((name ...) (map parse-name-val #'(name-val ...)))
-                     ((i ...) (iota (length #'(name-val ...)))))
+                     ((idx ...) (iota (length #'(name-val ...)))))
          (unless (unique-ids? #'(name ...))
            (syntax-violation 'define-enum
              "duplicated enum names" stx #'(name ...)))
@@ -35,9 +35,13 @@
            (define-syntax type-name
              (syntax-rules (name ...)
                ((_ name)
-                (%enum-ordinal->enum-no-assert new-type i)) ...
+                (%enum-ordinal->enum-no-assert new-type idx)) ...
                ((_ (x . _))
                 (syntax-violation 'type-name "invalid syntax" x))
                ((_ id)
                 (syntax-violation 'type-name "invalid enum name" id))))
-          )))))))
+
+           (define-syntax constructor
+             (syntax-rules ()
+               ((_ arg ...)
+                (enum-set new-type (type-name arg) ...)))))))))))


### PR DESCRIPTION
Almost three years ago, [Marc asked](https://srfi-email.schemers.org/srfi-209/msg/15550027/) for a version of `define-enum` that does most of its work at expansion time. I've finally gotten around to it. This set of commits adds it to the `contrib` directory of the SRFI 209 repo.

Unfortunately, I haven't been able to test it directly, since I haven't found an implementation with `syntax-case` and a SRFI 209 port (with all its dependencies). I'm working on it and will correct at a later date anything that's broken.